### PR TITLE
Add .swift-sample file

### DIFF
--- a/.swift-sample
+++ b/.swift-sample
@@ -1,0 +1,8 @@
+{
+"type": "sandbox",
+"title": "BlueCryptor",
+"description": "Learn how to use BlueCryptor",
+"swiftversion": "swift-3.0-RELEASE-ubuntu14.04",
+"giturl": "https://github.com/IBM-Swift/BlueCryptor-Sample.git",
+"gittag": "0.1.0"
+}


### PR DESCRIPTION
This PR adds a `.swift-sample` file to the repo. This metadata is crawled by the [Package Catalog](https://swiftpkgs.ng.bluemix.net/) and used to generate links through to the [Swift Sandbox](https://swiftlang.ng.bluemix.net/) showing how to use a particular package. We've created a sample package for BlueCryptor, which is what this metadata refers to.