### PR TITLE
fix error 'none' is unavailable: use [] for swift3

### DIFF
--- a/Sources/RSA.swift
+++ b/Sources/RSA.swift
@@ -48,7 +48,7 @@ public class RSA {
 				switch self {
 					
 				case .none:
-					return .none
+					return []
 				case .pkcs1:
 					return .PKCS1
 				case .md2:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Swift3: 'none' is unavailable: use [] to construct an empty option set ;

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

None Compile error

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x ] If applicable, I have updated the documentation accordingly.
- [x ] If applicable, I have added tests to cover my changes.
