### PR TITLE
Clean up context - fixes observed leak

### DIFF
--- a/Sources/HMAC.swift
+++ b/Sources/HMAC.swift
@@ -269,6 +269,9 @@ public class HMAC: Updatable {
 	/// Cleanup
 	///
     deinit {
+        #if os(Linux)
+            HMAC_CTX_cleanup(context)
+        #endif
         context.deallocate(capacity: 1)
     }
  


### PR DESCRIPTION
This is observed to fix the following leak (yellow line) under Ubuntu 16.04 with Swift 3.0.2:

![relo_parse_vs_k16_k144_sessiondate_500000](https://cloud.githubusercontent.com/assets/67206/23038597/3d1abf7a-f450-11e6-8609-71c4b5e7672a.png)