### PR TITLE
Swift 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE=ubuntu:18.04
     - os: osx
       osx_image: xcode9.2
@@ -43,6 +48,10 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+    - os: osx
+      osx_image: xcode10.1
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/Cryptor/Crypto.swift
+++ b/Sources/Cryptor/Crypto.swift
@@ -32,42 +32,42 @@ public protocol CryptoDigest {
 public extension CryptoDigest {
 	
     /// An MD2 digest of this object
-    public var md2: Self {
+    var md2: Self {
 		return self.digest(using: .md2)
 	}
 	
     /// An MD4 digest of this object
-    public var md4: Self {
+    var md4: Self {
 		return self.digest(using: .md4)
 	}
 	
     /// An MD5 digest of this object
-    public var md5: Self {
+    var md5: Self {
 		return self.digest(using: .md5)
  	}
 	
     /// An SHA1 digest of this object
-    public var sha1: Self {
+    var sha1: Self {
 		return self.digest(using: .sha1)
 	}
 	
     /// An SHA224 digest of this object
-    public var sha224: Self {
+    var sha224: Self {
 		return self.digest(using: .sha224)
 	}
 	
     /// An SHA256 digest of this object
-    public var sha256: Self {
+    var sha256: Self {
 		return self.digest(using: .sha256)
 	}
 	
     /// An SHA384 digest of this object
-    public var sha384: Self {
+    var sha384: Self {
 		return self.digest(using: .sha384)
 	}
 	
     /// An SHA512 digest of this object
-    public var sha512: Self {
+    var sha512: Self {
 		return self.digest(using: .sha512)
 	}
 }

--- a/Sources/Cryptor/Crypto.swift
+++ b/Sources/Cryptor/Crypto.swift
@@ -29,45 +29,45 @@ public protocol CryptoDigest {
 ///
 /// Extension to the CryptoDigest to return the digest appropriate to the selected algorithm.
 ///
-public extension CryptoDigest {
+extension CryptoDigest {
 	
     /// An MD2 digest of this object
-    var md2: Self {
+    public var md2: Self {
 		return self.digest(using: .md2)
 	}
 	
     /// An MD4 digest of this object
-    var md4: Self {
+    public var md4: Self {
 		return self.digest(using: .md4)
 	}
 	
     /// An MD5 digest of this object
-    var md5: Self {
+    public var md5: Self {
 		return self.digest(using: .md5)
  	}
 	
     /// An SHA1 digest of this object
-    var sha1: Self {
+    public var sha1: Self {
 		return self.digest(using: .sha1)
 	}
 	
     /// An SHA224 digest of this object
-    var sha224: Self {
+    public var sha224: Self {
 		return self.digest(using: .sha224)
 	}
 	
     /// An SHA256 digest of this object
-    var sha256: Self {
+    public var sha256: Self {
 		return self.digest(using: .sha256)
 	}
 	
     /// An SHA384 digest of this object
-    var sha384: Self {
+    public var sha384: Self {
 		return self.digest(using: .sha384)
 	}
 	
     /// An SHA512 digest of this object
-    var sha512: Self {
+    public var sha512: Self {
 		return self.digest(using: .sha512)
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a build against a Swift 5 development snapshot to Travis, and resolves Swift 5 compilation warnings.

The compiler now emits a warning if a redundant access control modifier is applied to a member of an extension.  This comes about if you declare an explicit access control modifier on the extension itself (ie. `public extension Foo`) and also on members (`public var Bar`).

There are two choices:  keep the default access modifier on the extension (and remove `public` from all members of the extension), or remove the default access modifier and ensure all members that should be `public` are marked as such.

I've chosen the latter, as I think it makes it more clear as to what forms part of our public API: things that are public are still marked as such.

(note: my understanding is that removing the `public` from the extension only affects the _default_ visibility of its members. Public members of the extension remain public.  See: https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html#ID25)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
