### PR TITLE
fix: make byteArray return empty array on failure instead of fatal error

### DIFF
--- a/Sources/Cryptor/Utilities.swift
+++ b/Sources/Cryptor/Utilities.swift
@@ -108,6 +108,7 @@ public struct CryptoUtils {
 			{
 				byteArray += [ (hexMSN << 4 | hexLSN) ]
 			} else {
+				// In the next major release this function should throw instead of returning an empty array.
 				return []
 			}
 		}

--- a/Sources/Cryptor/Utilities.swift
+++ b/Sources/Cryptor/Utilities.swift
@@ -71,7 +71,7 @@ public struct CryptoUtils {
 	///
 	/// - Returns: The hexadecimal value of the digit
 	///
-	static func convert(hexDigit digit: UnicodeScalar) -> UInt8 {
+	static func convert(hexDigit digit: UnicodeScalar) -> UInt8? {
 		
 		switch digit {
 			
@@ -85,7 +85,7 @@ public struct CryptoUtils {
 			return UInt8(digit.value - UnicodeScalar(unicodeScalarLiteral:"A").value + 0xa)
 			
 		default:
-			fatalError("convertHexDigit: Invalid hex digit")
+			return nil 
 		}
 	}
 	
@@ -94,7 +94,7 @@ public struct CryptoUtils {
 	///
 	/// - Parameter string: The hex string (must contain an even number of digits)
 	///
-	/// - Returns: A byte array
+	/// - Returns: A byte array or [] if the input is not valid hexadecimal
 	///
 	public static func byteArray(fromHex string: String) -> [UInt8] {
 		
@@ -102,13 +102,13 @@ public struct CryptoUtils {
 		var byteArray: [UInt8] = []
 		while let msn = iterator.next() {
 			
-			if let lsn = iterator.next() {
-				
-				byteArray += [ (convert(hexDigit: msn) << 4 | convert(hexDigit: lsn)) ]
-				
+			if let lsn = iterator.next(),
+				let hexMSN = convert(hexDigit: msn) ,
+				let hexLSN = convert(hexDigit: lsn)
+			{
+				byteArray += [ (hexMSN << 4 | hexLSN) ]
 			} else {
-				
-				fatalError("arrayFromHexString: String must contain even number of characters")
+				return []
 			}
 		}
 		return byteArray

--- a/Tests/CryptorTests/CryptorTests.swift
+++ b/Tests/CryptorTests/CryptorTests.swift
@@ -827,6 +827,14 @@ class CryptorTests: XCTestCase {
 		
 	}
 	
+	func testInvalidByteArray() {
+		
+		let InvalidCharacter = CryptoUtils.byteArray(fromHex: "ZZ")
+		XCTAssertEqual(InvalidCharacter, [])
+		let invalidLength = CryptoUtils.byteArray(fromHex: "deadfac")
+		XCTAssertEqual(invalidLength, [])
+	}
+	
 	func testZeroPadString() {
 		var key1tmp = [UInt8]("thekey".utf8)
 		key1tmp += [0, 0]

--- a/Tests/CryptorTests/CryptorTests.swift
+++ b/Tests/CryptorTests/CryptorTests.swift
@@ -71,6 +71,7 @@ class CryptorTests: XCTestCase {
 			("testHexStringFromArray", testHexStringFromArray),
 			("testHexNSStringFromArray", testHexNSStringFromArray),
 			("testHexListFromArray", testHexListFromArray),
+			("testInvalidByteArray", testInvalidByteArray),
 			("testZeroPadString", testZeroPadString),
 			("testGitHubIssue9", testGitHubIssue9),
 			("testGitHubIssue9StringCanary", testGitHubIssue9StringCanary),


### PR DESCRIPTION
## Description
This PR changes byteArray so that on failure it returns an empty array instead of throwing a fatal error.

## Motivation and Context
This is required because you make pass user code into the function (such as in Kitura-Session where a users Cookie is decoded). If it throws a fatal error on failure then a user can crash the system. If it returns an empty array the application can handle this in the correct way.

## How Has This Been Tested?
This has been tested within Kitura-Session. Using this code makes the session reject the cookie instead of throwing a fatal error and crashing the server.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.

