### PR TITLE
Update EVP_Final to EVP_Final_ex

### DIFF
--- a/Sources/Cryptor/StreamCryptor.swift
+++ b/Sources/Cryptor/StreamCryptor.swift
@@ -575,7 +575,7 @@ public class StreamCryptor {
 				rawStatus = EVP_EncryptInit_ex(.make(optional: self.context), .make(optional: algorithm.nativeValue(options: options)), nil, keyBuffer, ivBuffer)
 		
 			case .decrypt:
-				rawStatus = EVP_DecryptInit(.make(optional: self.context), .make(optional: algorithm.nativeValue(options: options)), keyBuffer, ivBuffer)
+				rawStatus = EVP_DecryptInit_ex(.make(optional: self.context), .make(optional: algorithm.nativeValue(options: options)), nil, keyBuffer, ivBuffer)
 			}
 		
 			if rawStatus == 0 {

--- a/Sources/Cryptor/StreamCryptor.swift
+++ b/Sources/Cryptor/StreamCryptor.swift
@@ -906,10 +906,10 @@ public class StreamCryptor {
 				switch self.operation {
 				
 				case .encrypt:
-					rawStatus = EVP_EncryptFinal(.make(optional: self.context), bufferOut, &outLength)
+					rawStatus = EVP_EncryptFinal_ex(.make(optional: self.context), bufferOut, &outLength)
 				
 				case .decrypt:
-					rawStatus = EVP_DecryptFinal(.make(optional: self.context), bufferOut, &outLength)
+					rawStatus = EVP_DecryptFinal_ex(.make(optional: self.context), bufferOut, &outLength)
 				}
 			
 				byteCountOut = Int(outLength)


### PR DESCRIPTION
To quote OpenSSL:

"The functions EVP_EncryptInit(), EVP_EncryptFinal(), EVP_DecryptInit(), EVP_CipherInit() and EVP_CipherFinal() are obsolete but are retained for compatibility with existing code. New code should use EVP_EncryptInit_ex(), EVP_EncryptFinal_ex(), EVP_DecryptInit_ex(), EVP_DecryptFinal_ex(), EVP_CipherInit_ex() and EVP_CipherFinal_ex() because they can reuse an existing context without allocating and freeing it up on each call."

Since they use the same API we can just update our functions to remove the warning.

This is a fix for issue #57 