### PR TITLE
Avoid warning on Xcode 11

### DIFF
--- a/Sources/Cryptor/Status.swift
+++ b/Sources/Cryptor/Status.swift
@@ -112,7 +112,7 @@ public enum Status: CCCryptorStatus, Swift.Error, CustomStringConvertible {
     ///
 	public static func fromRaw(status: CCCryptorStatus) -> Status? {
 		
-        var from = [
+        let from = [
             kCCSuccess: success,
             kCCParamError: paramError,
             kCCBufferTooSmall: bufferTooSmall,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<img width="560" alt="Screen Shot 2019-06-22 at 23 24 28" src="https://user-images.githubusercontent.com/147051/59965136-235b9f80-9545-11e9-993d-85f0ef77cd27.png">

This warning is raised on Xcode 11 when BlueCrypto is installed as dependency

## Motivation and Context

This variable should be immutable.

## How Has This Been Tested?

- Built on Xcode 10.2
- Built on Xcode 11
- Pass CI

## Checklist:

- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
